### PR TITLE
Add OpenSPH

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A curated list of awesome astrophysical simulation software
 | [Gizmo](http://www.tapir.caltech.edu/~phopkins/Site/GIZMO.html) | Flexible, massively-parallel, multi-physics simulation code. | ![](https://skillicons.dev/icons?i=c) | [![](https://skillicons.dev/icons?i=gitlab)](https://bitbucket.org/phopkins/gizmo-public/src/master/) | [<img src="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" width="45" height="40">](https://ui.adsabs.harvard.edu/abs/2015MNRAS.450...53H/abstract) |
 | [MAESTROeX](https://amrex-astro.github.io/MAESTROeX/) | Massively parallel low Mach number stellar hydrodynamics code. | ![](https://skillicons.dev/icons?i=cpp) | [![](https://skillicons.dev/icons?i=github)](https://github.com/AMReX-Astro/MAESTROeX) | [<img src="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" width="45" height="40">](https://ui.adsabs.harvard.edu/abs/2019ApJ...887..212F/abstract) |
 | [Nyx](https://amrex-astro.github.io/Nyx/) |  Adaptive mesh, cosmological hydrodynamics simulation code. | ![](https://skillicons.dev/icons?i=cpp) | [![](https://skillicons.dev/icons?i=github)](https://github.com/AMReX-Astro/Nyx) | [<img src="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" width="45" height="40">](https://ui.adsabs.harvard.edu/abs/2013ApJ...765...39A/abstract) |
+| [OpenSPH](https://pavelsevecek.github.io/) | Modular library and graphical tools for running and visualizing SPH and N-body simulations. | ![](https://skillicons.dev/icons?i=cpp) | [![](https://skillicons.dev/icons?i=gitlab)](https://gitlab.com/sevecekp/sph) | [<img src="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" width="45" height="40">](https://ui.adsabs.harvard.edu/abs/2019A%26A...629A.122S/abstract) |
 | [Pencil](http://pencil-code.nordita.org/) | High-order finite-difference code for compressible hydrodynamic flows with magnetic fields and particles. | ![](https://skillicons.dev/icons?i=fortran) | [![](https://skillicons.dev/icons?i=github)](https://github.com/pencil-code/pencil-code) | [<img src="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" width="45" height="40">](https://ui.adsabs.harvard.edu/abs/2010ascl.soft10060B/abstract) |
 | [PHANTOM](https://phantomsph.github.io/) | Smoothed particle hydrodynamics and magnetohydrodynamics code for astrophysics. | ![](https://skillicons.dev/icons?i=fortran) | [![](https://skillicons.dev/icons?i=github)](https://github.com/danieljprice/phantom) | [<img src="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" width="45" height="40">](https://ui.adsabs.harvard.edu/abs/2018PASA...35...31P/abstract) |
 | [PLUTO](http://plutocode.ph.unito.it/) | Code targeting high Mach number flows in astrophysical fluid dynamics. | ![](https://skillicons.dev/icons?i=c) | [![](https://skillicons.dev/icons?i=github)](https://github.com/JohannesBuchner/PLUTO) | [<img src="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" width="45" height="40">](http://adsabs.harvard.edu/abs/2007ApJS..170..228M) |
@@ -56,6 +57,7 @@ A curated list of awesome astrophysical simulation software
 | Gizmo     |                   | 🟩️️️️️            |                |          |     | 🟩️️️️️     |          |     | 🟩️️️️️         |     |
 | MAESTROeX |                   | 🟩️️️️️            |                |          |     |        | 🟩️️️️️       |     |            | 🟩️️️️️  |
 | Nyx       |                   | 🟩️️️️️            |                |          |     |        | 🟩️️️️️       |     |            | 🟩️️️️️  |
+| OpenSPH   |                   |               |                |          | 🟩️️️️️  | 🟩️️️️️     |          |     | 🟩️️️️️         |     |
 | Pencil    | 🟩️️️️️                |               |                |          |     |        | 🟩️️️️️       |     |            |     |
 | PLUTO     | 🟩️️️️️                | 🟩️            |                |          |     |        | 🟩️️️️️       |     |            | 🟩️  |
 | PHANTOM   |                   |               |                |          | 🟩️️️️️  | 🟩️️     |          |     | 🟩️️️️️         |     |
@@ -84,6 +86,7 @@ A curated list of awesome astrophysical simulation software
 | Gizmo     | 🟩️            | 🟩️  | 🟩️        | 🟩️           |                    |
 | MAESTROeX | 🟩️            | 🟩️  | 🟩️        | 🟩️           |                    |
 | Nyx       | 🟩️            | 🟩️  | 🟩️        | 🟩️           |                    |
+| OpenSPH   | 🟩️            |     |           | 🟩️           |                    |
 | Pencil    | 🟩️            | 🟩️  |           | 🟩️           |                    |
 | PLUTO     | 🟩️            | 🟩️  |           |              |                    |
 | PHANTOM   | 🟩️            |     |           | 🟩️           |                    |
@@ -112,6 +115,7 @@ A curated list of awesome astrophysical simulation software
 | Gizmo     | 🟩️  |     | 
 | MAESTROeX | 🟩️  | 🟩️  |
 | Nyx       | 🟩️  | 🟩️  |
+| OpenSPH   |     |     | 
 | Pencil    | 🟩️  |     | 
 | PLUTO     | 🟩️️️️️  |     | 
 | PHANTOM   | 🟩️  |     | 


### PR DESCRIPTION
Kind of a unique addition, [OpenSPH](https://pavelsevecek.github.io/) is a code maintained by [Pavel Ševeček](https://sirrah.troja.mff.cuni.cz/~sevecek/) which doesn't use a GPGPU library or even OpenMPI for parallelism, it is more or less intended to be ran on single-node workstations with lots of threads (e.g. Threadrippers) but can also be easily ran on lower-end devices, and even includes an intuitive graphical editor making it possible for people with no experience to play around with SPH, N-body, etc. It even has its own [Record in the Astrophysics Source Code Library (1911.003)](https://ascl.net/1911.003)
